### PR TITLE
update to latest version of wemore

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "dependencies": {
     "lodash": "^4.17.4",
-    "wemore": "^0.3.0"
+    "wemore": "^0.4.1"
   },
   "author": "@biddster",
   "license": "MIT",


### PR DESCRIPTION
The latest version of wemore allows to use the emulated device with homee, a smart home hub.